### PR TITLE
Add custom loss function. Closes #1

### DIFF
--- a/alphazero/__init__.py
+++ b/alphazero/__init__.py
@@ -1,3 +1,4 @@
 #! /usr/bin/python3
 
 from ._game import *
+from ._utils import *

--- a/alphazero/_utils.py
+++ b/alphazero/_utils.py
@@ -3,7 +3,9 @@
 import torch.nn as nn
 
 
-def AlphaGoZeroLoss(ground_truth, output, ratio=1):
+def AlphaGoZeroLoss(
+    ground_truth: (torch.Tensor, int), output: (torch.Tensor, int), ratio: int = 1
+):
     """
     Calculates AlphaGoZero style loss.
     L2 regularization is included in the optimizer and would be very slow to

--- a/alphazero/_utils.py
+++ b/alphazero/_utils.py
@@ -1,10 +1,13 @@
 #! /usr/bin/python3
 
+import torch
 import torch.nn as nn
 
 
 def AlphaGoZeroLoss(
-    ground_truth: (torch.Tensor, int), output: (torch.Tensor, int), ratio: int = 1
+    ground_truth: (torch.Tensor, torch.Tensor),
+    output: (torch.Tensor, torch.Tensor),
+    ratio: int = 1,
 ):
     """
     Calculates AlphaGoZero style loss.

--- a/alphazero/_utils.py
+++ b/alphazero/_utils.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 def AlphaGoZeroLoss(
     ground_truth: (torch.Tensor, torch.Tensor),
     output: (torch.Tensor, torch.Tensor),
-    ratio: int = 1,
+    ratio: float = 1.0,
 ):
     """
     Calculates AlphaGoZero style loss.

--- a/alphazero/_utils.py
+++ b/alphazero/_utils.py
@@ -1,0 +1,23 @@
+#! /usr/bin/python3
+
+import torch.nn as nn
+
+
+def AlphaGoZeroLoss(ground_truth, output, ratio=1):
+    """
+    Calculates AlphaGoZero style loss.
+    L2 regularization is included in the optimizer and would be very slow to
+    compute here, since it would require unpacking the parameters of the NN
+    at every step. So we're using it there instead.
+    """
+
+    mse = nn.MSELoss()
+    ce = nn.CrossEntropyLoss()
+
+    policy_true = ground_truth[0]
+    q_true = ground_truth[1]
+
+    policy = output[0]
+    q_value = output[1]
+
+    return mse(policy_true, policy) + ratio * ce(q_true, q_value)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,26 @@
+#! /usr/bin/python3
+
+import pytest
+from alphazero import *
+import torch
+
+
+class Test_Loss:
+    def test_alphazero_input(self):
+        policy_true = torch.Tensor([0.1, 0.1, 0.8])
+        q_true = torch.Tensor([[1000, 0]])
+
+        policy_pred = torch.Tensor([0.1, 0.1, 0.8])
+        q_pred = torch.LongTensor([0])
+
+        truth = (policy_true, q_true)
+        pred = (policy_pred, q_pred)
+
+        assert torch.allclose(AlphaGoZeroLoss(truth, pred), torch.Tensor([0]))
+
+        policy_pred = torch.Tensor([1.0, 0, 0])
+        q_pred = torch.LongTensor([1])
+
+        pred = (policy_pred, q_pred)
+
+        assert torch.allclose(AlphaGoZeroLoss(truth, pred), torch.Tensor([1000.4867]))


### PR DESCRIPTION
L2 loss is being left to the optimizer, since it would require unpacking the parameters of the network every time (as far as I know). I really wanted to make it part of the loss function itself, but I can't find a way to do it otherwise.